### PR TITLE
Fixes issues when exporting PagedLOD nodes to osgjs. Exporting option…

### DIFF
--- a/src/osgPlugins/osgjs/ReaderWriterJSON.cpp
+++ b/src/osgPlugins/osgjs/ReaderWriterJSON.cpp
@@ -48,6 +48,7 @@ public:
          bool varint;
          bool strictJson;
          std::vector<std::string> useSpecificBuffer;
+         std::string databasePath;
 
          OptionsStruct() {
              resizeTextureUpToPowerOf2 = 0;
@@ -57,6 +58,7 @@ public:
              inlineImages = false;
              varint = false;
              strictJson = true;
+             databasePath = "";
          }
     };
 
@@ -86,6 +88,9 @@ public:
         if (!acceptsExtension(ext)) return WriteResult::FILE_NOT_HANDLED;
 
         OptionsStruct _options = parseOptions(options);
+
+        _options.databasePath = options->getDatabasePathList().empty() ? osgDB::getFilePath(fileName) : options->getDatabasePathList().front();
+
         json_stream fout(fileName, _options.strictJson);
 
         if(fout) {
@@ -127,6 +132,7 @@ public:
             writer.inlineImages(options.inlineImages);
             writer.setMaxTextureDimension(options.resizeTextureUpToPowerOf2);
             writer.setVarint(options.varint);
+            writer.setDatabasePath(options.databasePath);
             for(std::vector<std::string>::const_iterator specificBuffer = options.useSpecificBuffer.begin() ;
                 specificBuffer != options.useSpecificBuffer.end() ; ++ specificBuffer) {
                 writer.addSpecificBuffer(*specificBuffer);

--- a/src/osgPlugins/osgjs/WriteVisitor
+++ b/src/osgPlugins/osgjs/WriteVisitor
@@ -59,6 +59,7 @@ public:
     int _maxTextureDimension;
     std::vector<std::string> _specificBuffers;
     std::map<std::string, std::ofstream*> _buffers;
+    std::string _databasePath;
 
     std::ofstream& getBufferFile(const std::string& name) {
         if(_buffers.find(name) == _buffers.end()) {
@@ -446,6 +447,7 @@ public:
     void setVarint(bool use) { _varint = use; }
     void setMaxTextureDimension(int use) { _maxTextureDimension = use; }
     void addSpecificBuffer(const std::string& bufferFlag) { _specificBuffers.push_back(bufferFlag); }
+    void setDatabasePath(const std::string& databasePath)  { _databasePath = databasePath; }
 };
 
 #endif

--- a/src/osgPlugins/osgjs/WriteVisitor.cpp
+++ b/src/osgPlugins/osgjs/WriteVisitor.cpp
@@ -648,6 +648,16 @@ JSONObject* WriteVisitor::createJSONPagedLOD(osg::PagedLOD *plod)
     }
     jsonPlod->getMaps()["RangeList"] = rangeObject;
     // File List
+    std::stringstream outputOptions;
+    outputOptions << std::boolalpha;
+    outputOptions << "resizeTextureUpToPowerOf2=" << std::to_string(_maxTextureDimension);
+    outputOptions << " useExternalBinaryArray=" << _useExternalBinaryArray;
+    outputOptions << " mergeAllBinaryFiles=" << _mergeAllBinaryFiles;
+    outputOptions << " inlineImages=" << _inlineImages;
+    outputOptions << " varint=" << _varint;
+
+    osg::ref_ptr<osgDB::Options> writeOpts = new osgDB::Options(outputOptions.str());
+    writeOpts->setDatabasePath(_databasePath);
 
     JSONObject* fileObject = new JSONObject;
     for (unsigned int i =0; i< plod->getNumFileNames(); i++)
@@ -661,7 +671,7 @@ JSONObject* WriteVisitor::createJSONPagedLOD(osg::PagedLOD *plod)
         if (n)
         {
             std::string filename(osgDB::getStrippedName(plod->getFileName(i))+".osgjs");
-            osgDB::writeNodeFile(*n,filename);
+            osgDB::writeNodeFile(*n, _databasePath + "/" + filename, writeOpts);
             fileObject->getMaps()[str] =  new JSONValue<std::string>(filename);
         }
         else


### PR DESCRIPTION
…s were not passed down when loading children in filelist. Uses databasePath to set the folder where the PagedLOD files are written