### PR TITLE
Removed hardcoded setObjectCacheHint when reading FBX. Memory usage ri…

### DIFF
--- a/src/osgPlugins/fbx/ReaderWriterFBX.cpp
+++ b/src/osgPlugins/fbx/ReaderWriterFBX.cpp
@@ -298,7 +298,6 @@ ReaderWriterFBX::readNode(const std::string& filenameInit,
                 localOptions = options->cloneOptions();
             else
                 localOptions = new osgDB::Options();
-            localOptions->setObjectCacheHint(osgDB::ReaderWriter::Options::CACHE_IMAGES);
 
             std::string filePath = osgDB::getFilePath(filename);
             FbxMaterialToOsgStateSet fbxMaterialToOsgStateSet(filePath, localOptions.get(), lightmapTextures);


### PR DESCRIPTION
…ses uncontrollably when loading complex models with big textures